### PR TITLE
Establish SSH connection after building

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
         keep: 2
       },
 
-      setup() {
+      willPrepare() {
         const ssh = this.readConfig('sshClient') || new node_ssh;
         return ssh.connect(this.readConfig('connection')).then((conn) => {
           this.log("SSH connection established.", {color: "green"});

--- a/tests/index-nodetest.js
+++ b/tests/index-nodetest.js
@@ -49,19 +49,19 @@ describe('simply-ssh', () => {
     assert.equal(plugin.name, 'simply-ssh');
   });
 
-  describe('setup hook:', () => {
+  describe('willPrepare hook:', () => {
     it('rejects when connection params missing', () => {
       delete context.config["simply-ssh"].connection;
       delete context.config["simply-ssh"].sshClient;
       plugin.beforeHook(context);
-      return assert.isRejected(plugin.setup(context)).then((e) => {
+      return assert.isRejected(plugin.willPrepare(context)).then((e) => {
         assert.equal(e.message, "config.host or config.sock must be provided");
       });
     });
 
     it('connects with valid params', () => {
       plugin.beforeHook(context);
-      return assert.isFulfilled(plugin.setup(context)).then((context) => {
+      return assert.isFulfilled(plugin.willPrepare(context)).then((context) => {
         assert.ok(mockUi.received(/SSH connection established/));
         assert.ok(context.ssh instanceof SshStub);
       });


### PR DESCRIPTION
This tackles #4 

Instead of establishing the SSH connection in setup(), it now does so in willPreprare(). This means that the SSH connection doesn't sit idle for that long.

I tested this with my app and it worked as expected!