### PR TITLE
Add ignorePattern config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-simply-ssh",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,16 +28,14 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -53,12 +51,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chai-as-promised": {
@@ -67,7 +65,7 @@
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
-        "check-error": "1.0.2"
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {
@@ -75,11 +73,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "check-error": {
@@ -94,21 +92,20 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-object": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/core-object/-/core-object-2.0.6.tgz",
       "integrity": "sha1-YBNLnED/abJ7wV6C25ReTfeClhs=",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.1.3"
       }
     },
     "debug": {
@@ -126,7 +123,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "diff": {
@@ -140,9 +137,9 @@
       "resolved": "https://registry.npmjs.org/ember-cli-deploy-plugin/-/ember-cli-deploy-plugin-0.2.9.tgz",
       "integrity": "sha1-o9OVuK2tfvaNi6zdCw9KYbz55lE=",
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "^1.0.0",
         "core-object": "2.0.6",
-        "lodash.clonedeep": "4.5.0"
+        "lodash.clonedeep": "^4.5.0"
       }
     },
     "escape-string-regexp": {
@@ -168,12 +165,12 @@
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-readlink": {
@@ -193,7 +190,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -214,8 +211,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -236,8 +233,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -275,9 +272,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -298,18 +295,17 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -353,7 +349,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -369,10 +365,10 @@
       "resolved": "https://registry.npmjs.org/node-ssh/-/node-ssh-4.2.3.tgz",
       "integrity": "sha512-rg9rJyIqGEjH/OPIkEoqwAK4K+rAh3CHogBBuWwfnSHBPGQ2b8LQNPgNa+8LkV4DDHhsfDNyUhfZq+XpN1FYow==",
       "requires": {
-        "sb-promisify": "2.0.2",
-        "sb-scandir": "1.0.0",
-        "shell-escape": "0.2.0",
-        "ssh2": "0.5.5"
+        "sb-promisify": "^2.0.1",
+        "sb-scandir": "^1.0.0",
+        "shell-escape": "^0.2.0",
+        "ssh2": "^0.5.0"
       }
     },
     "once": {
@@ -381,7 +377,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -411,7 +407,7 @@
       "resolved": "https://registry.npmjs.org/sb-scandir/-/sb-scandir-1.0.0.tgz",
       "integrity": "sha1-ECtGZse2RPQofw0zzrQ3T6wb+hU=",
       "requires": {
-        "sb-promisify": "1.3.0"
+        "sb-promisify": "^1.3.0"
       },
       "dependencies": {
         "sb-promisify": {
@@ -436,7 +432,7 @@
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.5.tgz",
       "integrity": "sha1-x3gezS7OcwSiU89iD6taXCK7IjU=",
       "requires": {
-        "ssh2-streams": "0.1.20"
+        "ssh2-streams": "~0.1.18"
       }
     },
     "ssh2-streams": {
@@ -444,9 +440,9 @@
       "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
       "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
       "requires": {
-        "asn1": "0.2.3",
-        "semver": "5.5.0",
-        "streamsearch": "0.1.2"
+        "asn1": "~0.2.0",
+        "semver": "^5.1.0",
+        "streamsearch": "~0.1.2"
       }
     },
     "streamsearch": {
@@ -459,7 +455,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "ember-cli-deploy-plugin": "0.2.9",
+    "minimatch": "^3.0.4",
     "node-ssh": "4.2.3",
     "rsvp": "^3.3.3"
   }

--- a/tests/index-nodetest.js
+++ b/tests/index-nodetest.js
@@ -5,7 +5,6 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const SshStub = require('./ssh-stub.js');
 const RSVP = require('rsvp');
-const minimatch = require('minimatch');
 const Plugin = require('../index.js');
 chai.use(chaiAsPromised);
 
@@ -142,11 +141,11 @@ describe('simply-ssh', () => {
     });
 
     it('uploads files one-by-one with -ignore-pattern', () => {
-      context.config["simply-ssh"].ignorePattern = "**/*.map";
+      context.config["simply-ssh"].ignorePattern = "*.map";
       plugin.beforeHook(context);
       return assert.isFulfilled(plugin.upload(context)).then((res) => {
         assert.ok(mockUi.received(/Uploading files/));
-        assert.notOk(mockUi.received(minimatch.makeRe("**/*.map", { matchBase: true })));
+        assert.notOk(mockUi.received(new RegExp("app.map")));
         assert.notOk(res);
       });
     });


### PR DESCRIPTION
Hi. This PR adds ignorePattern config which sometimes we need it.

For example: I upload my map files to Sentry but I don't want to upload to my server.

Simply we can update env like this and this is done.

```js
ENV['simply-ssh'] = {
  ignorePattern: '**/*.map',
};
```

Thank you.